### PR TITLE
Add React-styled blog with Lucide icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.jekyll-cache/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,9 @@
 <header class="site-header">
   <div class="wrapper">
-    {%- assign default_paths = site.pages | map: "path" -%}
-    {%- assign page_paths = site.minima.nav_pages | default: default_paths -%}
-    {%- assign page_titles = site.pages | map: 'title' | compact %}
     <a class="site-title" rel="author" href="{{ '/' | relative_url }}">{{ site.title | escape }}</a>
-    <!-- Removed nav to avoid duplicate site name and give a clean header -->
+    <nav class="site-nav">
+      <a href="{{ '/' | relative_url }}" aria-label="Home"><i data-lucide="home"></i></a>
+      <a href="{{ '/blog' | relative_url }}" aria-label="Blog"><i data-lucide="pen-line"></i></a>
+    </nav>
   </div>
 </header>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+<div id="blog-root"></div>
+
+<script type="text/babel">
+  const posts = [
+    {% for post in site.posts %}
+      { title: "{{ post.title | escape }}", date: "{{ post.date | date: '%Y-%m-%d' }}", url: "{{ post.url | relative_url }}" }{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+  ];
+
+  function Blog() {
+    return (
+      <ul className="post-list">
+        {posts.map(post => (
+          <li key={post.url}>
+            <h2><a href={post.url}>{post.title}</a></h2>
+            <p className="post-meta">{post.date}</p>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById('blog-root')).render(<Blog />);
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title }} | {{ site.title }}</title>
+  <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
+</head>
+<body>
+  {% include header.html %}
+  <main class="wrapper">
+    {{ content }}
+  </main>
+
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script src="https://unpkg.com/lucide@latest"></script>
+  <script>
+    lucide.createIcons();
+  </script>
+</body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,10 @@
+---
+layout: default
+---
+<article class="post">
+  <h1 class="post-title">{{ page.title }}</h1>
+  <p class="post-meta">{{ page.date | date: "%B %-d, %Y" }}</p>
+  <div class="post-content">
+    {{ content }}
+  </div>
+</article>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -92,7 +92,22 @@ h3 { font-size: 1.25rem; margin-top: 1.5rem; }
 }
 
 /* If Minima shows a nav with the site title again, hide it */
-.site-nav { display: none !important; }
+/* Navigation with icons */
+.site-nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.site-nav a {
+  color: $text;
+  display: inline-flex;
+  align-items: center;
+}
+
+.site-nav svg {
+  width: 24px;
+  height: 24px;
+}
 
 /* =========================
    FOOTER

--- a/blog.md
+++ b/blog.md
@@ -1,0 +1,6 @@
+---
+layout: blog
+title: "Blog"
+---
+
+<!-- The React component will render here -->

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
-layout: home
+layout: default
 title: "The Office of Nils Johansson"
 ---
 
-Welcome to my website.
+Welcome to my website. Visit the [blog](/blog) <i data-lucide="pen-line"></i> for stories and updates.


### PR DESCRIPTION
## Summary
- Integrate custom default layout loading React and Lucide icons
- Add React-rendered blog page fed by Markdown posts
- Style navigation bar with Lucide icon links and update index page

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68c7c11595ec8322b2a46360e60f0a79