### PR TITLE
Implement adaptive responsive layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -34,17 +34,18 @@
   --radius-medium: 14px;
   --radius-small: 10px;
 
-  /* Type scale */
-  --font-largetitle: 34px;
-  --font-title1: 28px;
-  --font-title2: 22px;
-  --font-title3: 20px;
-  --font-headline: 17px;
-  --font-body: 16px;
-  --font-callout: 15px;
-  --font-subheadline: 14px;
-  --font-footnote: 13px;
-  --font-caption1: 12px;
+  /* Dynamic typography */
+  --type-scale: 1;
+  --font-largetitle: calc(clamp(2.25rem, 4vw, 3.25rem) * var(--type-scale));
+  --font-title1: calc(clamp(1.9rem, 3vw, 2.6rem) * var(--type-scale));
+  --font-title2: calc(clamp(1.4rem, 2.4vw, 1.9rem) * var(--type-scale));
+  --font-title3: calc(clamp(1.2rem, 1.8vw, 1.6rem) * var(--type-scale));
+  --font-headline: calc(clamp(1.05rem, 1.2vw, 1.3rem) * var(--type-scale));
+  --font-body: calc(clamp(0.98rem, 0.28vw + 0.92rem, 1.12rem) * var(--type-scale));
+  --font-callout: calc(clamp(0.95rem, 0.25vw + 0.9rem, 1.08rem) * var(--type-scale));
+  --font-subheadline: calc(clamp(0.88rem, 0.22vw + 0.84rem, 1.02rem) * var(--type-scale));
+  --font-footnote: calc(clamp(0.82rem, 0.2vw + 0.78rem, 0.95rem) * var(--type-scale));
+  --font-caption1: calc(clamp(0.75rem, 0.18vw + 0.72rem, 0.88rem) * var(--type-scale));
 
   /* Spacing (8pt grid) */
   --spacing-0: 0px;
@@ -62,14 +63,66 @@
   --spacing-20: 80px;
 
   /* Layout */
+  --page-horizontal-padding: clamp(1.5rem, 4.6vw, 3.2rem);
+  --page-vertical-padding: clamp(2.4rem, 8vw, 4.6rem);
+  --layout-column-gap: clamp(1.4rem, 5vw, 2.8rem);
   --content-max-width: 1140px;
-  --context-width: 300px;
+  --reading-max-width: min(650px, 100%);
 }
 
 @media (min-width: 1440px) {
   :root {
     --content-max-width: 1280px;
-    --context-width: 320px;
+    --page-horizontal-padding: clamp(2.6rem, 4vw, 4.2rem);
+    --layout-column-gap: clamp(1.8rem, 3vw, 3rem);
+  }
+}
+
+@media (max-width: 600px) {
+  :root {
+    --type-scale: 0.96;
+    --page-horizontal-padding: clamp(1rem, 6vw, 1.4rem);
+    --page-vertical-padding: clamp(1.8rem, 8vw, 2.4rem);
+    --layout-column-gap: clamp(1rem, 5vw, 1.6rem);
+  }
+
+  .post-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .content .slider-field {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .content .slider-field__label {
+    min-width: 0;
+  }
+
+  .content .hotel-list {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 380px) {
+  :root {
+    --type-scale: 0.9;
+    --page-horizontal-padding: clamp(0.85rem, 7vw, 1.1rem);
+    --page-vertical-padding: clamp(1.6rem, 10vw, 2.1rem);
+  }
+}
+
+@media (orientation: landscape) and (max-width: 900px) {
+  :root {
+    --page-vertical-padding: clamp(1.4rem, 5vw, 2rem);
+  }
+
+  .masthead {
+    position: sticky;
+  }
+
+  .bottom-nav {
+    padding-bottom: calc(0.55rem + env(safe-area-inset-bottom));
   }
 }
 
@@ -160,7 +213,10 @@ button:focus-visible,
 .masthead__inner {
   max-width: var(--content-max-width);
   margin: 0 auto;
-  padding: var(--spacing-4) clamp(var(--spacing-4), 4vw, var(--spacing-8));
+  padding-top: var(--spacing-4);
+  padding-bottom: var(--spacing-4);
+  padding-left: max(clamp(var(--spacing-4), 4vw, var(--spacing-8)), env(safe-area-inset-left));
+  padding-right: max(clamp(var(--spacing-4), 4vw, var(--spacing-8)), env(safe-area-inset-right));
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -266,35 +322,45 @@ button:focus-visible,
   width: 100%;
   flex: 1;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(240px, var(--context-width));
-  gap: clamp(var(--spacing-10), 7vw, var(--spacing-16));
+  grid-template-areas:
+    "timeline"
+    "context"
+    "inspector";
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--layout-column-gap);
   max-width: var(--content-max-width);
   margin: 0 auto;
-  padding: var(--spacing-12) clamp(var(--spacing-4), 4vw, var(--spacing-8)) var(--spacing-20);
   align-items: start;
+  padding-top: var(--page-vertical-padding);
+  padding-bottom: calc(var(--page-vertical-padding) + env(safe-area-inset-bottom));
+  padding-left: max(var(--page-horizontal-padding), env(safe-area-inset-left));
+  padding-right: max(var(--page-horizontal-padding), env(safe-area-inset-right));
 }
 
 .timeline {
+  grid-area: timeline;
   display: flex;
   flex-direction: column;
   gap: var(--spacing-8);
-  max-width: 760px;
+  width: 100%;
+  max-width: min(100%, 920px);
+  margin: 0 auto;
 }
 
 .timeline--detail {
   gap: var(--spacing-10);
 }
 
-@media (max-width: 1100px) {
-  .app-main {
-    grid-template-columns: minmax(0, 1fr);
-  }
+.post-grid {
+  display: grid;
+  width: 100%;
+  gap: var(--card-gap);
+  margin: 0 auto;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
 
-  .context-panel {
-    position: static;
-    width: 100%;
-    order: 2;
-  }
+.post-grid > * {
+  width: 100%;
 }
 
 @media (max-width: 820px) {
@@ -313,20 +379,107 @@ button:focus-visible,
     bottom: 0;
   }
 
-  .app-main {
-    padding: var(--spacing-10) var(--spacing-4) var(--spacing-16);
-  }
-
   .bottom-nav {
     display: flex;
   }
 
-  .context-panel {
-    display: none;
-  }
-
   .hero {
     padding: var(--spacing-8) var(--spacing-6);
+  }
+
+  .content table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .content table thead,
+  .content table tbody {
+    display: table;
+    width: max-content;
+    min-width: 100%;
+  }
+}
+
+@media (max-width: 820px) {
+  .app-main {
+    grid-template-areas:
+      "timeline"
+      "context"
+      "inspector";
+  }
+
+  .context-panel,
+  .inspector-panel {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) {
+  :root {
+    --type-scale: 1.02;
+    --page-horizontal-padding: clamp(2.1rem, 6vw, 3.1rem);
+    --layout-column-gap: clamp(1.6rem, 4vw, 2.6rem);
+  }
+
+  .app-main {
+    grid-template-columns: minmax(220px, 0.34fr) minmax(0, 0.66fr);
+    grid-template-areas: "context timeline";
+  }
+
+  .context-panel {
+    display: grid;
+    position: sticky;
+    top: calc(var(--page-vertical-padding) + env(safe-area-inset-top) - 1.5rem);
+    align-self: start;
+  }
+
+  .context-panel::after {
+    content: "";
+    display: block;
+    height: env(safe-area-inset-bottom);
+  }
+}
+
+@media (min-width: 1024px) {
+  :root {
+    --type-scale: 1.05;
+  }
+
+  .app-main {
+    grid-template-columns: minmax(240px, 0.25fr) minmax(0, 0.5fr) minmax(240px, 0.25fr);
+    grid-template-areas: "context timeline inspector";
+  }
+
+  .inspector-panel {
+    display: grid;
+    position: sticky;
+    top: calc(var(--page-vertical-padding) + env(safe-area-inset-top) - 1.5rem);
+    align-self: start;
+  }
+
+  .inspector-panel::after {
+    content: "";
+    display: block;
+    height: env(safe-area-inset-bottom);
+  }
+
+  .post-grid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+}
+
+@media (min-width: 1366px) {
+  :root {
+    --type-scale: 1.08;
+  }
+
+  .app-main {
+    grid-template-columns: minmax(260px, 0.22fr) minmax(0, 0.56fr) minmax(260px, 0.22fr);
+  }
+
+  .post-grid {
+    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
   }
 }
 
@@ -430,6 +583,7 @@ button:focus-visible,
   font-size: var(--font-body);
   border: 1px solid transparent;
   transition: background 0.2s ease, transform 0.2s ease;
+  min-height: 44px;
 }
 
 .primary-button:hover {
@@ -532,6 +686,287 @@ button:focus-visible,
   color: var(--ink-primary);
 }
 
+.timeline-card__body.content {
+  padding-top: 0.2rem;
+}
+
+.content {
+  display: grid;
+  gap: 1.4rem;
+  width: 100%;
+  max-width: var(--reading-max-width);
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.content > * {
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.content p {
+  margin: 0;
+  font-size: var(--font-body);
+  line-height: 1.6;
+  color: var(--ink-secondary);
+}
+
+.content p + p {
+  margin-top: 1.1rem;
+}
+
+.content h2,
+.content h3,
+.content h4 {
+  margin: 2rem 0 1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--ink-primary);
+}
+
+.content h2 {
+  font-size: var(--font-title2);
+}
+
+.content h3 {
+  font-size: var(--font-title3);
+}
+
+.content h4 {
+  font-size: var(--font-headline);
+}
+
+.content ul,
+.content ol {
+  margin: 0;
+  padding-left: 1.3rem;
+  display: grid;
+  gap: 0.6rem;
+  color: var(--ink-secondary);
+}
+
+.content li::marker {
+  color: var(--ink-tertiary);
+}
+
+.content blockquote {
+  margin: 1.6rem auto;
+  padding: 1rem 1.4rem;
+  border-left: 4px solid rgba(0, 102, 204, 0.35);
+  background: rgba(0, 102, 204, 0.08);
+  border-radius: 0 18px 18px 0;
+  color: var(--ink-primary);
+  font-style: italic;
+}
+
+.content code {
+  font-family: "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.9em;
+  background: rgba(60, 60, 67, 0.08);
+  border-radius: 6px;
+  padding: 0.1rem 0.35rem;
+}
+
+.content pre {
+  background: #1e1e20;
+  color: #f5f5f7;
+  border-radius: 16px;
+  padding: 1.1rem 1.3rem;
+  overflow-x: auto;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.content figure {
+  margin: 1.6rem auto;
+  width: 100%;
+  max-width: var(--reading-max-width);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.content figure img,
+.content img {
+  width: 100%;
+  height: auto;
+  border-radius: calc(var(--card-radius) - 8px);
+  display: block;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.12);
+}
+
+.content figcaption {
+  font-size: var(--font-footnote);
+  color: var(--ink-tertiary);
+  text-align: center;
+}
+
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.6rem auto;
+  font-size: var(--font-body);
+  line-height: 1.5;
+  box-shadow: inset 0 0 0 1px rgba(60, 60, 67, 0.08);
+  border-radius: var(--radius-medium);
+  overflow: hidden;
+}
+
+.content table th,
+.content table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(60, 60, 67, 0.08);
+}
+
+.content table th {
+  font-weight: 600;
+  background: rgba(60, 60, 67, 0.06);
+}
+
+.content table tr:last-of-type td {
+  border-bottom: none;
+}
+
+.content .table-scroll {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.content .table-scroll table {
+  min-width: 520px;
+}
+
+.content form,
+.content .audit-form {
+  width: 100%;
+  max-width: min(100%, 700px);
+  margin: 1.4rem auto;
+  display: grid;
+  gap: 1rem;
+  background: var(--surface-primary);
+  border-radius: var(--card-radius);
+  border: 1px solid var(--separator);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+}
+
+.content .audit-form__row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.content label {
+  font-weight: 600;
+  font-size: var(--font-subheadline);
+  color: var(--ink-primary);
+}
+
+.content input,
+.content select,
+.content textarea,
+.content input[type="range"] {
+  width: 100%;
+  min-height: 44px;
+  border-radius: 12px;
+  border: 1px solid rgba(60, 60, 67, 0.16);
+  padding: 0.6rem 0.9rem;
+  font-size: var(--font-body);
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.content textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.content input:focus,
+.content select:focus,
+.content textarea:focus,
+.content input[type="range"]:focus {
+  border-color: var(--accent-contrast);
+  box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.15);
+  outline: none;
+}
+
+.content .slider-field {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.content .slider-field__label {
+  flex: 1 1 160px;
+  min-width: 140px;
+  font-size: var(--font-footnote);
+  color: var(--ink-secondary);
+}
+
+.content .slider-field__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--ink-primary);
+}
+
+.content .hotel-list {
+  display: grid;
+  gap: 0.8rem;
+  margin: 1.2rem auto;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.content .hotel-card {
+  background: var(--surface-primary);
+  border: 1px solid var(--separator);
+  border-radius: var(--card-radius);
+  padding: clamp(1rem, 3vw, 1.4rem);
+  display: grid;
+  gap: 0.4rem;
+  box-shadow: 0 14px 36px rgba(15, 23, 42, 0.08);
+}
+
+.content .hotel-card__title {
+  margin: 0;
+  font-size: var(--font-headline);
+  font-weight: 600;
+}
+
+.content .hotel-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: var(--font-footnote);
+  color: var(--ink-secondary);
+  justify-content: space-between;
+}
+
+.content .hotel-card__meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.content .hotel-card__actions {
+  margin-top: 0.6rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.content .hotel-card__actions .pill-button {
+  flex: 1 1 160px;
+}
+
+.content .audit-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  justify-content: flex-end;
+}
+
 .timeline-card__stats {
   display: flex;
   flex-wrap: wrap;
@@ -622,17 +1057,17 @@ button:focus-visible,
   background: var(--accent-soft);
   color: var(--ink-primary);
   border: 1px solid var(--separator);
+  min-height: 44px;
+  justify-content: center;
 }
 
 .context-panel {
-  width: var(--context-width);
-  display: flex;
-  flex-direction: column;
+  grid-area: context;
+  display: none;
   gap: 1.4rem;
-  position: sticky;
-  top: 2.4rem;
-  align-self: flex-start;
-  margin-top: var(--spacing-2);
+  width: 100%;
+  align-self: stretch;
+  position: relative;
 }
 
 .context-card {
@@ -641,6 +1076,86 @@ button:focus-visible,
   border: 1px solid var(--separator);
   box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
   padding: clamp(1.2rem, 3vw, 1.6rem);
+}
+
+.inspector-panel {
+  grid-area: inspector;
+  display: none;
+  gap: 1.4rem;
+  width: 100%;
+  align-self: stretch;
+  position: relative;
+}
+
+.inspector-card {
+  background: var(--surface-primary);
+  border-radius: var(--card-radius);
+  border: 1px solid var(--separator);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+  padding: clamp(1.15rem, 2.6vw, 1.55rem);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.inspector-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.inspector-card__meta {
+  font-size: 0.9rem;
+  color: var(--ink-secondary);
+  line-height: 1.5;
+}
+
+.inspector-card__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.inspector-card__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 12px;
+  background: rgba(0, 102, 204, 0.06);
+  color: var(--ink-secondary);
+  font-size: 0.9rem;
+}
+
+.inspector-card__value {
+  font-weight: 600;
+  color: var(--ink-primary);
+  text-align: right;
+}
+
+.inspector-card__kbd {
+  font-family: "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-weight: 600;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 102, 204, 0.22);
+  background: rgba(0, 102, 204, 0.08);
+  color: var(--accent-contrast);
+}
+
+.inspector-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.inspector-card__actions .pill-button {
+  flex: 1 1 160px;
+  justify-content: center;
 }
 
 .context-card__title {
@@ -794,8 +1309,8 @@ button:focus-visible,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 38px;
-  height: 38px;
+  width: 44px;
+  height: 44px;
   border-radius: 50%;
   border: 1px solid rgba(60, 60, 67, 0.16);
   background: rgba(255, 255, 255, 0.78);
@@ -1387,6 +1902,7 @@ button:focus-visible,
   gap: 0.2rem;
   padding: 0.4rem 0;
   color: var(--ink-tertiary);
+  min-height: 44px;
 }
 
 .bottom-nav__item.active {


### PR DESCRIPTION
## Summary
- add a large-screen inspector panel with quick actions and document keyboard shortcuts for navigation and search
- refactor layouts to use adaptive grid areas, safe-area padding, and a reusable post grid that scales from compact phones to desktop widths
- tune content styling for readable articles, responsive media, and resizable forms/tables to avoid overflow on small devices

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68cfeb9e095883228ef83bd4c0a2791c